### PR TITLE
fix(sftp): ask before trusting an unknown host key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - The Site Manager has its Browse button back for choosing a private key file, and it opens where the current path points rather than at your home folder.
 
 ### Fixed
+- Connecting to an unknown SSH host with "Ask before trusting a new server" (the default) now shows a dialog to reject the key, accept it once, or accept it permanently, instead of refusing every new host. Reject is the default, so Enter and Escape both refuse.
 - Alt+U reached both Duplicate and Username in the Site Manager, and Alt+P reached both Play and Preview in the sound pack window, so neither letter activated anything. Each access key now reaches one control.
 - Accepting a host key could stop a different server from connecting. The new entry was written onto the end of the last line when the known hosts file did not end in a newline, which corrupted both; the server recorded there then looked like it had changed its key, and a changed key is refused outright. Existing files are repaired the next time a key is accepted.
 - The first server in the known hosts file was not recognised if the file began with a byte order mark, as one written by some Windows editors does.

--- a/crates/portkeydrop/src/ui/dialogs/host_key.rs
+++ b/crates/portkeydrop/src/ui/dialogs/host_key.rs
@@ -1,0 +1,166 @@
+//! Unknown SSH host key prompt.
+//!
+//! Reject is the default: Enter and Escape both refuse the key. The other two
+//! buttons accept it for this session or remember it.
+
+use portkeydrop_core::protocols::HostKeyDecision;
+use wxdragon::prelude::*;
+
+/// Window title, and the accessible name of the dialog.
+pub const TITLE: &str = "Unknown Host Key";
+
+/// Accept-once button id, above wxWidgets' reserved range.
+const ID_ACCEPT_ONCE: i32 = 6101;
+/// Accept-permanently button id.
+const ID_ACCEPT_PERMANENT: i32 = 6102;
+
+/// The line above the key details.
+pub fn intro_text() -> &'static str {
+    "The server identity could not be verified."
+}
+
+/// Host, algorithm, and fingerprint, one per line.
+pub fn details_text(host: &str, algorithm: &str, fingerprint: &str) -> String {
+    format!("Host: {host}\nKey type: {algorithm}\nFingerprint: {fingerprint}")
+}
+
+/// The question under the details.
+pub fn question_text() -> &'static str {
+    "Do you want to connect?"
+}
+
+/// Map a modal return code onto a decision.
+///
+/// Anything that is not one of the two accept buttons — Escape, the title-bar
+/// close box, or Reject itself — is a refusal.
+pub fn decision_from_code(code: i32) -> HostKeyDecision {
+    if code == ID_ACCEPT_ONCE {
+        HostKeyDecision::AcceptOnce
+    } else if code == ID_ACCEPT_PERMANENT {
+        HostKeyDecision::AcceptPermanent
+    } else {
+        HostKeyDecision::Reject
+    }
+}
+
+/// Ask what to do about an untrusted host key.
+pub fn show(
+    parent: &dyn WxWidget,
+    host: &str,
+    algorithm: &str,
+    fingerprint: &str,
+) -> HostKeyDecision {
+    let dialog = Dialog::builder(parent, TITLE)
+        .with_size(520, 280)
+        .with_style(DialogStyle::DefaultDialogStyle | DialogStyle::ResizeBorder)
+        .build();
+
+    let sizer = BoxSizer::builder(Orientation::Vertical).build();
+
+    let intro = StaticText::builder(&dialog)
+        .with_label(intro_text())
+        .build();
+    sizer.add(&intro, 0, SizerFlag::Expand | SizerFlag::All, 8);
+
+    // This label must sit immediately before the details: a screen reader
+    // takes the control's name from the preceding sibling.
+    let details_label = StaticText::builder(&dialog)
+        .with_label("Host key details:")
+        .build();
+    sizer.add(&details_label, 0, SizerFlag::Left | SizerFlag::All, 8);
+
+    let details = TextCtrl::builder(&dialog)
+        .with_style(TextCtrlStyle::MultiLine | TextCtrlStyle::ReadOnly)
+        .build();
+    details.set_value(&details_text(host, algorithm, fingerprint));
+    details.set_name("Host key details");
+    sizer.add(&details, 1, SizerFlag::Expand | SizerFlag::All, 8);
+
+    let question = StaticText::builder(&dialog)
+        .with_label(question_text())
+        .build();
+    sizer.add(&question, 0, SizerFlag::Expand | SizerFlag::All, 8);
+
+    let buttons = BoxSizer::builder(Orientation::Horizontal).build();
+
+    let accept_permanent = Button::builder(&dialog)
+        .with_id(ID_ACCEPT_PERMANENT)
+        .with_label("&Accept Permanently")
+        .build();
+    accept_permanent.set_name("Accept Permanently");
+    let accept_once = Button::builder(&dialog)
+        .with_id(ID_ACCEPT_ONCE)
+        .with_label("Accept &Once")
+        .build();
+    accept_once.set_name("Accept Once");
+    // ID_NO so the title-bar close box and Escape share Reject's meaning.
+    let reject = Button::builder(&dialog)
+        .with_id(ID_NO)
+        .with_label("&Reject")
+        .build();
+    reject.set_name("Reject");
+
+    buttons.add(&accept_permanent, 0, SizerFlag::All, 4);
+    buttons.add(&accept_once, 0, SizerFlag::All, 4);
+    buttons.add(&reject, 0, SizerFlag::All, 4);
+    sizer.add_sizer(&buttons, 0, SizerFlag::AlignRight | SizerFlag::All, 8);
+
+    // Custom ids do not close a modal dialog on their own.
+    accept_permanent.on_click(move |_| dialog.end_modal(ID_ACCEPT_PERMANENT));
+    accept_once.on_click(move |_| dialog.end_modal(ID_ACCEPT_ONCE));
+    reject.on_click(move |_| dialog.end_modal(ID_NO));
+
+    dialog.set_sizer(sizer, true);
+    dialog.set_escape_id(ID_NO);
+    // Reject is the safest default: Enter refuses without the user having to
+    // find the button, and a screen reader announces it first.
+    reject.set_default();
+    reject.set_focus();
+
+    let answer = dialog.show_modal();
+    dialog.destroy();
+    decision_from_code(answer)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_title_is_the_accessible_name() {
+        // SetName on a dialog is not what screen readers read; the title is.
+        assert_eq!(TITLE, "Unknown Host Key");
+    }
+
+    #[test]
+    fn the_details_name_the_host_the_algorithm_and_the_fingerprint() {
+        let text = details_text("example.com", "ssh-ed25519", "SHA256:abc");
+        assert!(text.contains("example.com"), "{text}");
+        assert!(text.contains("ssh-ed25519"), "{text}");
+        assert!(text.contains("SHA256:abc"), "{text}");
+        assert!(text.contains("Host:"), "{text}");
+        assert!(text.contains("Key type:"), "{text}");
+        assert!(text.contains("Fingerprint:"), "{text}");
+    }
+
+    #[test]
+    fn accept_once_and_permanent_are_distinct_from_reject() {
+        assert_eq!(
+            decision_from_code(ID_ACCEPT_ONCE),
+            HostKeyDecision::AcceptOnce
+        );
+        assert_eq!(
+            decision_from_code(ID_ACCEPT_PERMANENT),
+            HostKeyDecision::AcceptPermanent
+        );
+        assert_eq!(decision_from_code(ID_NO), HostKeyDecision::Reject);
+        assert_eq!(decision_from_code(ID_CANCEL), HostKeyDecision::Reject);
+        assert_eq!(decision_from_code(0), HostKeyDecision::Reject);
+    }
+
+    #[test]
+    fn the_question_asks_whether_to_connect() {
+        assert!(question_text().contains("connect"));
+        assert!(intro_text().contains("verified"));
+    }
+}

--- a/crates/portkeydrop/src/ui/dialogs/mod.rs
+++ b/crates/portkeydrop/src/ui/dialogs/mod.rs
@@ -4,6 +4,7 @@
 //! OK/Cancel, every control given an accessible name, and the initial focus put
 //! on the first thing the user will want to change.
 
+pub mod host_key;
 pub mod import;
 pub mod properties;
 pub mod settings;
@@ -98,6 +99,7 @@ mod tests {
         // Adding a menu item without its dialog would otherwise fail only when
         // the user clicked it.
         fn _assert_modules() {
+            let _ = super::host_key::TITLE;
             let _ = super::import::TITLE;
             let _ = super::properties::TITLE;
             let _ = super::settings::TITLE;

--- a/crates/portkeydrop/src/ui/events.rs
+++ b/crates/portkeydrop/src/ui/events.rs
@@ -9,7 +9,7 @@
 use std::path::PathBuf;
 use std::sync::mpsc::{Receiver, Sender};
 
-use portkeydrop_core::protocols::RemoteFile;
+use portkeydrop_core::protocols::{HostKeyDecision, RemoteFile};
 use portkeydrop_core::updater::UpdateInfo;
 
 /// Something that happened away from the UI thread.
@@ -55,6 +55,17 @@ pub enum AppEvent {
     TrayCommand(i32),
     /// A line for the activity log.
     Log { message: String },
+    /// An unknown SSH host key; the worker is blocked on `reply`.
+    ///
+    /// The UI thread shows the dialog and sends the answer. Dropping this
+    /// without answering is a rejection: that is the safe choice if the
+    /// window has gone.
+    HostKeyPrompt {
+        host: String,
+        algorithm: String,
+        fingerprint: String,
+        reply: Sender<HostKeyDecision>,
+    },
 }
 
 /// The result of an update check.
@@ -104,6 +115,29 @@ pub fn post(sender: &EventSender, event: AppEvent) {
 /// Drain every event currently waiting, without blocking.
 pub fn drain(receiver: &EventReceiver) -> Vec<AppEvent> {
     receiver.try_iter().collect()
+}
+
+/// Ask the UI thread what to do about an untrusted host key.
+///
+/// Posts a prompt and blocks until the UI answers. If the window has gone,
+/// the channel is closed and the key is refused.
+pub fn ask_host_key(
+    sender: &EventSender,
+    host: &str,
+    algorithm: &str,
+    fingerprint: &str,
+) -> HostKeyDecision {
+    let (reply, reply_rx) = std::sync::mpsc::channel();
+    post(
+        sender,
+        AppEvent::HostKeyPrompt {
+            host: host.to_string(),
+            algorithm: algorithm.to_string(),
+            fingerprint: fingerprint.to_string(),
+            reply,
+        },
+    );
+    reply_rx.recv().unwrap_or(HostKeyDecision::Reject)
 }
 
 #[cfg(test)]
@@ -188,5 +222,56 @@ mod tests {
 
         let events = drain(&receiver);
         assert!(matches!(events.first(), Some(AppEvent::Connected { .. })));
+    }
+
+    #[test]
+    fn a_host_key_prompt_carries_the_offer_and_the_answer() {
+        // The connect worker blocks on the reply; the UI thread is what
+        // actually talks to the user. This is that round trip without a
+        // display.
+        let (sender, receiver) = channel();
+        let worker = std::thread::spawn(move || {
+            ask_host_key(&sender, "example.com", "ssh-ed25519", "SHA256:abc")
+        });
+
+        match receiver.recv().expect("the prompt is posted") {
+            AppEvent::HostKeyPrompt {
+                host,
+                algorithm,
+                fingerprint,
+                reply,
+            } => {
+                assert_eq!(host, "example.com");
+                assert_eq!(algorithm, "ssh-ed25519");
+                assert_eq!(fingerprint, "SHA256:abc");
+                reply
+                    .send(HostKeyDecision::AcceptPermanent)
+                    .expect("the worker is waiting");
+            }
+            other => panic!("expected a host key prompt, got {other:?}"),
+        }
+
+        assert_eq!(
+            worker.join().expect("the worker finished"),
+            HostKeyDecision::AcceptPermanent
+        );
+    }
+
+    #[test]
+    fn a_host_key_prompt_with_no_answer_is_a_rejection() {
+        // Closing the window while the worker is waiting must not hang, and
+        // must not accept the key.
+        let (sender, receiver) = channel();
+        let worker = std::thread::spawn(move || {
+            ask_host_key(&sender, "example.com", "ssh-ed25519", "SHA256:abc")
+        });
+
+        let event = receiver.recv().expect("the prompt is posted");
+        drop(event);
+
+        assert_eq!(
+            worker.join().expect("the worker finished"),
+            HostKeyDecision::Reject
+        );
     }
 }

--- a/crates/portkeydrop/src/ui/main_frame.rs
+++ b/crates/portkeydrop/src/ui/main_frame.rs
@@ -17,10 +17,11 @@ use std::sync::Arc;
 
 use wxdragon::prelude::*;
 
-use portkeydrop_core::protocols::{self, ConnectionInfo, HostKeyDecision, HostKeyPolicy, Protocol};
+use portkeydrop_core::protocols::{self, ConnectionInfo, HostKeyPolicy, Protocol};
 use portkeydrop_core::transfer::TransferJob;
 use portkeydrop_core::{local_files, APP_NAME};
 
+use super::dialogs;
 use super::events::{self, AppEvent, EventReceiver, EventSender};
 use super::file_pane::FilePane;
 use super::format;
@@ -708,6 +709,21 @@ impl MainFrame {
             AppEvent::UpdateDownloadDone(outcome) => self.on_download_done(*outcome),
             AppEvent::TrayCommand(id) => self.handle_tray_command(id),
             AppEvent::Log { message } => self.log(&message),
+            AppEvent::HostKeyPrompt {
+                host,
+                algorithm,
+                fingerprint,
+                reply,
+            } => {
+                self.log(&format!(
+                    "{host} offered an unrecognised {algorithm} host key ({fingerprint})."
+                ));
+                let decision =
+                    dialogs::host_key::show(&self.frame, &host, &algorithm, &fingerprint);
+                if reply.send(decision).is_err() {
+                    log::debug!("host key answer dropped: the connect worker has gone");
+                }
+            }
         }
     }
 
@@ -854,22 +870,13 @@ impl MainFrame {
 
         let sender = self.sender.clone();
         let host = info.host.clone();
-        // The host key prompt runs on this worker thread and blocks it, which
-        // is safe: the UI thread is free, and the answer is needed before the
-        // connection can continue.
+        // The prompt posts onto the event pump and blocks this worker until
+        // the UI thread answers. That is safe: the UI thread is free, and
+        // wxWidgets dialogs cannot run anywhere else.
         let prompt_sender = sender.clone();
         let host_key_prompt: protocols::HostKeyPrompt =
             Arc::new(move |host: &str, algorithm: &str, fingerprint: &str| {
-                events::post(
-                    &prompt_sender,
-                    AppEvent::Log {
-                        message: format!(
-                            "{host} offered an unrecognised {algorithm} host key ({fingerprint})."
-                        ),
-                    },
-                );
-                // Without a UI answer the safe choice is to refuse.
-                HostKeyDecision::Reject
+                events::ask_host_key(&prompt_sender, host, algorithm, fingerprint)
             });
 
         std::thread::spawn(move || {

--- a/crates/portkeydrop/tests/dialog_mnemonics.rs
+++ b/crates/portkeydrop/tests/dialog_mnemonics.rs
@@ -167,6 +167,11 @@ fn the_sound_pack_access_keys_are_unique() {
 }
 
 #[test]
+fn the_host_key_access_keys_are_unique() {
+    assert_unique("host_key.rs");
+}
+
+#[test]
 fn the_scanner_finds_the_mnemonics_it_should_and_ignores_the_rest() {
     // Guards the test itself: a scanner that quietly found nothing would make
     // every dialog above pass.


### PR DESCRIPTION
## What was wrong

The nightly's default host key policy is **Ask before trusting a new server**. Connecting to an unknown SSH host logged the key and then always refused it. There was no dialog.

The connect worker is not allowed to touch wxWidgets, and the Rust port left the prompt as a stub that returned `Reject`. Setting **Trust any server** connected on the nightly, which is how this was confirmed.

## What this does

The worker posts a `HostKeyPrompt` onto the existing UI event pump and blocks until the UI thread answers. The dialog shows the host, key type, and fingerprint, with **Accept Permanently**, **Accept Once**, and **Reject**. Reject is the default: Enter and Escape both refuse. Closing the window without answering is also a refusal.

Once this is in a nightly, switch the setting back to Ask if it was changed to Trust any server in order to connect.

## Tests

- Worker-to-UI round trip without a display (answer unblocks; dropping the event rejects)
- Dialog wording and return-code mapping
- Unique access keys on the three buttons (`A` / `O` / `R`)
