### PR TITLE
fix(ci): preserve Windows wxWidgets build between runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,24 +155,39 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Install Rust
+      id: rust
       uses: dtolnay/rust-toolchain@stable
       with:
         components: clippy
 
-    # wxdragon-sys downloads wxWidgets and builds it with CMake, which is
-    # nearly all of a cold build. Two settings matter more than they look:
-    #
-    # cache-on-failure keeps that work when a later step fails. Without it
-    # a run that dies packaging the installer throws away forty minutes of
-    # C++ compilation, and the next attempt starts from nothing again.
-    #
-    # shared-key lets this job reuse what CI built on the same OS instead
-    # of each workflow keeping its own copy.
+    # This preserves Cargo dependencies, but rust-cache's cleanup deletes
+    # wxdragon-sys 0.9.18's extra directories at the target/profile level.
+    # Preserve those separately below, before the post-job cleanup runs.
     - name: Cache cargo artifacts
       uses: Swatinem/rust-cache@v2
       with:
         cache-on-failure: true
         shared-key: ${{ runner.os }}
+
+    - name: Identify native build environment
+      id: native-env
+      shell: pwsh
+      run: |
+        if (-not $env:ImageVersion) { throw 'Missing runner image version' }
+        "image=$env:ImageVersion" >> $env:GITHUB_OUTPUT
+
+    # Exact matches only: CMake trees contain compiler paths and build flags.
+    # Include the runner image, Rust, dependency/features and this workflow.
+    # Keep the source tree too: the CMake trees refer to its absolute path.
+    - name: Restore wxWidgets build
+      id: native-cache
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          target/debug/wxWidgets
+          target/debug/wxwidgets_cmake_build
+          target/debug/wxdragon_sys_cmake_build
+        key: windows-wx-v1-${{ runner.arch }}-${{ steps.native-env.outputs.image }}-${{ steps.rust.outputs.cachekey }}-${{ hashFiles('Cargo.lock', '**/Cargo.toml', '.cargo/config*', '.github/workflows/ci.yml') }}
 
     # The full workspace, including the wxWidgets front end. One platform
     # rather than three: wxdragon-sys builds wxWidgets from source, so a
@@ -181,6 +196,18 @@ jobs:
     # surfaces.
     - name: Clippy
       run: cargo clippy --workspace --all-targets
+
+    # Save immediately after a successful native build. A later test failure
+    # must not lose it, and rust-cache's post-job cleanup must not erase it.
+    - name: Save wxWidgets build
+      if: steps.native-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          target/debug/wxWidgets
+          target/debug/wxwidgets_cmake_build
+          target/debug/wxdragon_sys_cmake_build
+        key: ${{ steps.native-cache.outputs.cache-primary-key }}
 
     - name: Test
       run: cargo test --workspace


### PR DESCRIPTION
Windows CI restores the Rust cache but still rebuilds wxWidgets: rust-cache's cleanup retains only build, .fingerprint and deps under each target profile, removing wxdragon-sys 0.9.18's native source and CMake trees before saving. The completed PR #151 run had an exact 261 MB cache hit, yet Clippy/build took 8m38s and test compilation took 2m37s.

This change separately restores the three target/debug wxWidgets and wrapper directories and saves them immediately after successful Clippy, before post-job cleanup or a later test failure. Exact cache keys include the Windows runner image, architecture, Rust compiler, dependency lockfile, manifests, Cargo config and workflow. No fallback keys reuse incompatible CMake trees. Existing Cargo caching and every test remain enabled.

The published wxdragon-sys 0.9.18 does not support the newer build-directory environment overrides described by upstream main, so this uses its actual default paths without a dependency upgrade. Scope is the Windows CI job; release packaging is unchanged.

Validation: actionlint 1.7.7 passed; git diff --check passed; paths verified against the published 0.9.18 build.rs and cleanup behavior against the exact rust-cache revision in the completed run.

Windows verification completed on the same commit and runner image. First run: Clippy/build 9m53s, test compilation 2m25s; native cache saved successfully. Windows-only rerun: exact native-cache hit (526 MB) and exact Rust-cache hit (605 MB), Clippy/build 25.14s, test compilation 39.27s, all tests passing. Combined compilation fell from 12m18s to about 64 seconds (91% lower). This measures cold versus warm use of both caches, not an isolated native-cache-only benchmark. Native cache restoration took about 16 seconds.

Evidence: https://github.com/Orinks/PortkeyDrop/actions/runs/34186314682/job/101935237945 and https://github.com/Orinks/PortkeyDrop/actions/runs/34186314682/job/101942040942. All checks, including Windows, Ubuntu, formatting, changelog, release tooling and GitGuardian, passed on 9475f6ed77a7bde8d8ae97b0d2aec13e3b5f0764. Cold caches and runner/compiler/dependency changes still require rebuilding.

Changelog: none